### PR TITLE
Fix classify model reuse

### DIFF
--- a/Draft_Replies.py
+++ b/Draft_Replies.py
@@ -39,7 +39,6 @@ import json
 # -------------------------------------------------------
 # Module 1 - Classify incoming email
 # -------------------------------------------------------
-CLASSIFY_MODEL = OPENAI_MODEL
 
 
 def classify_email(raw_txt: str) -> dict:


### PR DESCRIPTION
## Summary
- retain environment-based `CLASSIFY_MODEL` definition
- remove duplicate reassignment to ensure the env value is used

## Testing
- `python3 -m py_compile Draft_Replies.py`


------
https://chatgpt.com/codex/tasks/task_e_68645c4e92a0832b93e8590c5bbeddb1