### PR TITLE
Fix classify_email prompt

### DIFF
--- a/Draft_Replies.py
+++ b/Draft_Replies.py
@@ -179,9 +179,7 @@ def classify_email(text: str) -> dict:
                 {
                     "role": "system",
                     "content": (
-                        "Categorize the email as 'lead', 'customer', or 'other' "
-                        "and provide an importance rating from 0-10. Return JSON "
-                        "{\"type\":<type>, \"importance\":<importance>}"
+                        "Categorize the email as lead, customer, or other. Return ONLY JSON {\"type\":\"lead|customer|other\",\"importance\":1-10}. NO other text."
                     ),
                 },
                 {"role": "user", "content": text},


### PR DESCRIPTION
## Summary
- follow new spec for classify_email output: only JSON with type and importance

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile Draft_Replies.py`


------
https://chatgpt.com/codex/tasks/task_e_6864604aa3bc832ba641a0a96c92bfc7