### PR TITLE
Implement new main loop for gmail bot

### DIFF
--- a/gmail_bot.py
+++ b/gmail_bot.py
@@ -3,7 +3,7 @@ import os
 # additional imports
 import json
 import requests
-from Draft_Replies import generate_ai_reply
+from Draft_Replies import generate_ai_reply, classify_email, critic_email
 
 from googleapiclient.discovery import build     # already imported in Draft_Replies, keep here too
 from google.auth.transport.requests import Request
@@ -103,4 +103,57 @@ def process_messages(service, unread_messages):
         if email_type == "other":
             continue
         # further processing will be added later
+
+
+def main():
+    svc = get_gmail_service()
+    for ref in fetch_all_unread_messages(svc):
+        msg = (
+            svc.users()
+            .messages()
+            .get(userId="me", id=ref["id"], format="full")
+            .execute()
+        )
+        subject = next(
+            (h["value"] for h in msg["payload"]["headers"] if h["name"] == "Subject"),
+            "",
+        )
+        sender = next(
+            (h["value"] for h in msg["payload"]["headers"] if h["name"] == "From"),
+            "",
+        )
+        thread = msg["threadId"]
+
+        part = msg["payload"]["parts"][0]["body"]["data"]
+        body = base64.urlsafe_b64decode(part).decode("utf-8", "ignore")
+        snippet = msg.get("snippet", "")
+
+        cls = classify_email(f"Subject:{subject}\n\n{body}")
+        email_type, importance = cls["type"], cls["importance"]
+
+        if email_type == "other":
+            continue
+
+        if not thread_has_draft(svc, thread):
+            draft_text = generate_ai_reply(subject, sender, snippet, email_type)
+            for _ in range(MAX_RETRIES):
+                rating = critic_email(draft_text, body)
+                if rating["score"] >= CRITIC_THRESHOLD:
+                    break
+                draft_text = generate_ai_reply(
+                    subject,
+                    sender,
+                    f"{snippet}\n\nCritic feedback: {rating['feedback']}",
+                    email_type,
+                )
+            msg_draft = create_base64_message("me", sender, f"Re: {subject}", draft_text)
+            create_draft(svc, "me", msg_draft, thread_id=thread)
+
+        create_ticket(subject, sender, body)
+
+        print(f"{ref['id'][:8]}… {email_type:<8} imp={importance}")
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- import `classify_email` and `critic_email` for use in the gmail bot
- rewrite gmail bot's main loop to classify emails, skip `other` types, create drafts with OpenAI, and open tickets
- add script entry point

## Testing
- `python -m py_compile gmail_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686464595cb4832ba4f9c2b8a9fe39dc