### PR TITLE
Fix circular import in Gmail bot

### DIFF
--- a/Draft_Replies.py
+++ b/Draft_Replies.py
@@ -7,9 +7,6 @@ from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-# Bring in ticket creation helper and critic threshold from gmail_bot
-from gmail_bot import CRITIC_THRESHOLD, create_ticket, thread_has_draft
-
 # -------------------------------------------------------
 # 1) Configuration
 # -------------------------------------------------------


### PR DESCRIPTION
## Summary
- eliminate circular imports between `gmail_bot.py` and `Draft_Replies.py`
- keep classification helpers inside `gmail_bot.py`

## Testing
- `python -m py_compile gmail_bot.py Draft_Replies.py`

------
https://chatgpt.com/codex/tasks/task_e_686465ebd808832b94e934aaa44ecf8b