### PR TITLE
Fix circular imports and cleanup Gmail bot

### DIFF
--- a/Draft_Replies.py
+++ b/Draft_Replies.py
@@ -7,9 +7,6 @@ from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-# Bring in ticket creation helper and critic threshold from gmail_bot
-from gmail_bot import CRITIC_THRESHOLD, create_ticket, thread_has_draft
-
 # -------------------------------------------------------
 # 1) Configuration
 # -------------------------------------------------------

--- a/gmail_bot.py
+++ b/gmail_bot.py
@@ -8,6 +8,8 @@ from googleapiclient.discovery import build     # already imported in Draft_Repl
 from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 import pickle, base64
+from openai import OpenAI
+from Draft_Replies import generate_ai_reply
 
 SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 
@@ -62,6 +64,7 @@ def thread_has_draft(service, thread_id):
 # — model choices —
 CLASSIFY_MODEL  = "gpt-4.1"
 DRAFT_MODEL     = "o3"
+OPENAI_API_KEY  = os.getenv("OPENAI_API_KEY")
 
 # — routing & thresholds —
 TICKET_SYSTEM   = "freescout"
@@ -94,18 +97,51 @@ def create_ticket(subject: str, sender: str, body: str):
     r.raise_for_status()
 
 
-def process_messages(service, unread_messages):
-    """Placeholder for the upcoming main loop rewrite."""
-    for msg in unread_messages:
-        email_type = "other"
-        # classification will set email_type in Module G
-        if email_type == "other":
-            continue
-        # further processing will be added later
+def critic_email(draft: str, original: str) -> dict:
+    """Self-grade a draft reply using GPT-4.1."""
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    resp = client.chat.completions.create(
+        model=CLASSIFY_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Return ONLY JSON {\"score\":1-10,\"feedback\":\"...\"} "
+                    "rating on correctness, tone, length."
+                ),
+            },
+            {"role": "assistant", "content": draft},
+            {"role": "user", "content": f"Original email:\n\n{original}"},
+        ],
+    )
+    return json.loads(resp.choices[0].message.content)
+
+
+def classify_email(text: str) -> dict:
+    """Classify an email and return a dict with type and importance."""
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    try:
+        response = client.chat.completions.create(
+            model=CLASSIFY_MODEL,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Categorize the email as lead, customer, or other. Return ONLY JSON {\"type\":\"lead|customer|other\",\"importance\":1-10}. NO other text."
+                    ),
+                },
+                {"role": "user", "content": text},
+            ],
+            temperature=0,
+            max_tokens=50,
+        )
+        return json.loads(response.choices[0].message.content)
+    except Exception as e:
+        print(f"Error classifying email: {e}")
+        return {"type": "other", "importance": 0}
 
 
 def main():
-    from Draft_Replies import generate_ai_reply, classify_email, critic_email
 
     svc = get_gmail_service()
     for ref in fetch_all_unread_messages(svc):


### PR DESCRIPTION
## Summary
- stop Draft_Replies from importing `gmail_bot`
- move `critic_email` and `classify_email` into `gmail_bot`
- import `generate_ai_reply` at module level in `gmail_bot`
- remove unused placeholder function

## Testing
- `python -m py_compile Draft_Replies.py gmail_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686465ebd808832b94e934aaa44ecf8b