### PR TITLE
Add YAML config loading for Gmail bot

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+openai:
+  api_key_env: OPENAI_API_KEY        # name of env var or you can inline a key (not recommended)
+  classify_model: "gpt-4.1"
+  draft_model:    "o3"
+
+thresholds:
+  critic_threshold: 8.0
+  max_retries:      2
+
+ticket:
+  system:         "freescout"        # or "helpscout", "freshdesk", etc.
+  freescout_url:  ""                 # fill in your desk URL
+  freescout_key:  ""                 # or set FREESCOUT_KEY env var
+
+gmail:
+  scopes:
+    - "https://www.googleapis.com/auth/gmail.modify"
+  client_secret_file: "client_secret.json"
+  token_file:         "token.pickle"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ google-auth
 google-auth-oauthlib
 google-api-python-client
 requests
+pyyaml


### PR DESCRIPTION
## Summary
- add new `config.yaml` for application settings
- load settings from YAML in `gmail_bot.py` and `Draft_Replies.py`
- update Gmail auth helper to use config values
- add `pyyaml` to requirements

## Testing
- `python -m py_compile gmail_bot.py Draft_Replies.py`


------
https://chatgpt.com/codex/tasks/task_e_686467a304a0832bbad4ba7a69944f11