### PR TITLE
Add promo-email skip logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 1. Reads all **unread** Gmail messages.
 2. Uses **GPT-4.1** to classify each as `lead`, `customer`, or `other` and assign an `importance` score (1-10).
-3. Ignores `other`.
+3. Ignores `other` and automatically skips promotional or newsletter emails
+   based on Gmail labels or unsubscribe headers.
 4. For leads & customers:
    * Drafts a reply with **o3** (never sends).
    * Runs a self-critique loop until the draft scores ≥ 8.


### PR DESCRIPTION
## Summary
- ignore newsletters or spam before classification
- add promotional label checks
- document promotional skip feature

## Testing
- `python -m py_compile gmail_bot.py Draft_Replies.py`

------
https://chatgpt.com/codex/tasks/task_e_6864a531209c832bb00496abd10fee52