### PR TITLE
Add ticket router and status polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@
 3. Ignores `other` and automatically skips promotional or newsletter emails
    based on Gmail labels or unsubscribe headers.
 4. For leads & customers:
-   * Drafts a reply with **o3** (never sends).
-   * Runs a self-critique loop until the draft scores ≥ 8.
-   * Saves the draft to Gmail.
-   * Opens a ticket in FreeScout.
-5. Prints a one-line log per processed email.
+    * Drafts a reply with **o3** (never sends).
+    * Runs a self-critique loop until the draft scores ≥ 8.
+    * Saves the draft to Gmail.
+    * Opens a ticket in FreeScout when classified as a lead or customer.
+5. For messages lacking detail or when ticket creation fails:
+    * Drafts a reply asking for additional information.
+6. Polls FreeScout for recent ticket updates and logs the status.
 
 ---
 


### PR DESCRIPTION
## Summary
- add routing logic to post tickets or draft info requests
- implement retry logic for ticket creation
- poll FreeScout for recent ticket updates
- update README to describe new workflow

## Testing
- `python -m py_compile gmail_bot.py Draft_Replies.py`

------
https://chatgpt.com/codex/tasks/task_e_686a097546c4832bb13909be4d67b86a