### PR TITLE
Add email routing and ticket polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 2. Uses **GPT-4.1** to classify each as `lead`, `customer`, or `other` and assign an `importance` score (1-10).
 3. Ignores `other` and automatically skips promotional or newsletter emails
    based on Gmail labels or unsubscribe headers.
-4. For leads & customers:
-   * Drafts a reply with **o3** (never sends).
-   * Runs a self-critique loop until the draft scores ≥ 8.
-   * Saves the draft to Gmail.
-   * Opens a ticket in FreeScout.
+4. Routes each message:
+   * High-importance emails open a ticket in **FreeScout** with retry logic.
+   * Lower-importance emails get a draft asking for more details.
+   * Drafts are self-critiqued until scoring ≥ 8 and then saved to Gmail.
 5. Prints a one-line log per processed email.
+6. Polls FreeScout for recent ticket updates after processing.
 
 ---
 


### PR DESCRIPTION
## Summary
- route new messages to ticket or draft
- add retry logic when creating tickets
- poll FreeScout for recent updates
- document new behavior in README

## Testing
- `python -m py_compile gmail_bot.py Draft_Replies.py`
- `python gmail_bot.py --gmail-query ""` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_686aa2ad1558832b86c3d2e83caaeaac