### PR TITLE
Refactor helpers into utils

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 180

--- a/Draft_Replies.py
+++ b/Draft_Replies.py
@@ -1,14 +1,13 @@
+from openai import OpenAI
 import os
-import pickle
 import base64
-import json
-import requests
-from email.mime.text import MIMEText
-from google.auth.transport.requests import Request
-from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build
 import yaml
 import argparse
+from utils import (
+    get_gmail_service, fetch_all_unread_messages, create_base64_message,
+    create_draft, thread_has_draft, is_promotional_or_spam,
+    critic_email, classify_email, create_ticket
+)
 
 # -------------------------------------------------------
 # 1) Configuration
@@ -23,7 +22,8 @@ SCOPES = CFG["gmail"]["scopes"]
 # Load OpenAI API key from env (never store in plain text!)
 OPENAI_API_KEY = os.getenv(CFG["openai"]["api_key_env"])
 if not OPENAI_API_KEY:
-    raise ValueError(f"Please set your {CFG['openai']['api_key_env']} environment variable.")
+    raise ValueError(
+        f"Please set your {CFG['openai']['api_key_env']} environment variable.")
 
 # Default to the o3 model unless overridden in config
 DRAFT_MODEL = CFG["openai"]["draft_model"]
@@ -39,17 +39,21 @@ CLASSIFY_MAX_TOKENS = CFG["openai"].get("classify_max_tokens", 50)
 
 # Critic settings
 CRITIC_THRESHOLD = CFG["thresholds"]["critic_threshold"]
-MAX_RETRIES      = CFG["thresholds"]["max_retries"]
+MAX_RETRIES = CFG["thresholds"]["max_retries"]
 
 MAX_DRAFTS = CFG.get("limits", {}).get("max_drafts", 100)
 GMAIL_QUERY = CFG["gmail"].get("query", "is:unread")
 HTTP_TIMEOUT = CFG.get("http", {}).get("timeout", 15)
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Draft Gmail replies")
-    parser.add_argument("--gmail-query", default=GMAIL_QUERY, help="Gmail search query")
-    parser.add_argument("--timeout", type=int, default=HTTP_TIMEOUT, help="HTTP request timeout")
+    parser.add_argument("--gmail-query", default=GMAIL_QUERY,
+                        help="Gmail search query")
+    parser.add_argument("--timeout", type=int,
+                        default=HTTP_TIMEOUT, help="HTTP request timeout")
     return parser.parse_args()
+
 
 # Ticketing configuration
 TICKET_SYSTEM = CFG["ticket"]["system"]
@@ -68,7 +72,6 @@ PROMO_LABELS = {
 
 
 # We'll use the new v1.0.0+ style:
-from openai import OpenAI
 
 
 # -------------------------------------------------------
@@ -82,93 +85,9 @@ from openai import OpenAI
 # -------------------------------------------------------
 # Module 3 - Evaluate AI Drafts
 # -------------------------------------------------------
-def critic_email(draft: str, original: str) -> dict:
-    """Self-grade a draft reply using GPT-4.1."""
-    client = OpenAI(api_key=OPENAI_API_KEY)
-    resp = client.chat.completions.create(
-        model=CLASSIFY_MODEL,
-        messages=[
-            {
-                "role": "system",
-                "content": (
-                    "Return ONLY JSON {\"score\":1-10,\"feedback\":\"...\"} "
-                    "rating on correctness, tone, length."
-                ),
-            },
-            {"role": "assistant", "content": draft},
-            {"role": "user", "content": f"Original email:\n\n{original}"},
-        ],
-    )
-    return json.loads(resp.choices[0].message.content)
-
-
-# -------------------------------------------------------
 # 2) Gmail Service Setup
 # -------------------------------------------------------
-def get_gmail_service(
-    creds_filename: str | None = None,
-    token_filename: str | None = None,
-):
-    """Authenticate with Gmail API and return a service resource.
-
-    Filenames may be supplied via arguments or will default to the values
-    specified in ``config.yaml``.
-    """
-    creds_filename = creds_filename or CFG["gmail"]["client_secret_file"]
-    token_filename = token_filename or CFG["gmail"]["token_file"]
-    creds = None
-
-    # Load token if it exists
-    if os.path.exists(token_filename):
-        with open(token_filename, "rb") as token:
-            creds = pickle.load(token)
-
-    # If no valid credentials, prompt for login
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(creds_filename, SCOPES)
-            creds = flow.run_local_server(port=0)
-        # Save the token for future runs
-        with open(token_filename, "wb") as token:
-            pickle.dump(creds, token)
-
-    # Build the Gmail service
-    service = build("gmail", "v1", credentials=creds)
-    return service
-
-
-# -------------------------------------------------------
 # 3) Fetching Unread Messages
-# -------------------------------------------------------
-def fetch_all_unread_messages(service, query: str = GMAIL_QUERY):
-    """
-    Fetch all unread messages in the Gmail inbox, handling pagination.
-    We'll then slice to only the configured number in ``main``.
-    """
-    unread_messages = []
-    page_token = None
-
-    while True:
-        response = (
-            service.users()
-            .messages()
-            .list(userId="me", q=query, pageToken=page_token)
-            .execute()
-        )
-        messages_page = response.get("messages", [])
-        if not messages_page:
-            break
-
-        unread_messages.extend(messages_page)
-        page_token = response.get("nextPageToken")
-        if not page_token:
-            break
-
-    return unread_messages
-
-
 # -------------------------------------------------------
 # 4) Email Processing Helpers
 # -------------------------------------------------------
@@ -181,107 +100,9 @@ def get_header_value(message, header_name):
         if header.get("name", "").lower() == header_name.lower():
             return header.get("value", "")
     return ""
-
-
-def create_base64_message(sender, to, subject, body_text):
-    """
-    Create a MIMEText email and encode it in base64 for the Gmail API.
-    """
-    msg = MIMEText(body_text)
-    msg["to"] = to
-    msg["from"] = sender
-    msg["subject"] = subject
-
-    raw_bytes = base64.urlsafe_b64encode(msg.as_bytes())
-    return {"raw": raw_bytes.decode("utf-8")}
-
-
-def create_draft(service, user_id, message_body, thread_id=None):
-    """
-    Create and insert a draft email.
-    """
-    try:
-        body = {"message": message_body}
-        if thread_id:
-            body["message"]["threadId"] = thread_id
-
-        draft = service.users().drafts().create(userId=user_id, body=body).execute()
-        return draft
-    except Exception as error:
-        print(f"An error occurred creating the draft: {error}")
-        return None
-
-
-def thread_has_draft(service, thread_id):
-    """Return True if a Gmail thread already contains a draft."""
-    data = service.users().threads().get(userId="me", id=thread_id).execute()
-    return any(
-        "DRAFT" in (m.get("labelIds") or []) for m in data.get("messages", [])
-    )
-
-
-def create_ticket(subject: str, sender: str, body: str):
-    if TICKET_SYSTEM != "freescout":
-        return
-    url = f"{FREESCOUT_URL.rstrip('/')}/api/conversations"
-    payload = {
-        "type": "email",
-        "subject": subject or "(no subject)",
-        "customer": {"email": sender},
-        "threads": [{"type": "customer", "text": body}],
-    }
-    resp = requests.post(
-        url,
-        headers={
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "X-FreeScout-API-Key": FREESCOUT_KEY,
-        },
-        json=payload,
-        timeout=15,
-    )
-    resp.raise_for_status()
-
-
-def is_promotional_or_spam(message, body_text: str) -> bool:
-    """Return True if the message looks like a newsletter or spam."""
-    labels = set(message.get("labelIds", []))
-    if labels & PROMO_LABELS:
-        return True
-    headers = {h.get("name", "").lower(): h.get("value", "") for h in message.get("payload", {}).get("headers", [])}
-    if "list-unsubscribe" in headers or "list-id" in headers:
-        return True
-    if "unsubscribe" in body_text.lower():
-        return True
-    return False
-
-
-def classify_email(text: str) -> dict:
-    """Classify an email and return a dict with type and importance."""
-    client = OpenAI(api_key=OPENAI_API_KEY)
-    try:
-        response = client.chat.completions.create(
-            model=CLASSIFY_MODEL,
-            messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "Categorize the email as lead, customer, or other. Return ONLY JSON {\"type\":\"lead|customer|other\",\"importance\":1-10}. NO other text."
-                    ),
-                },
-                {"role": "user", "content": text},
-            ],
-            temperature=0,
-            max_tokens=CLASSIFY_MAX_TOKENS,
-        )
-        return json.loads(response.choices[0].message.content)
-    except Exception as e:
-        print(f"Error classifying email: {e}")
-        return {"type": "other", "importance": 0}
-
-
-# -------------------------------------------------------
 # 5) OpenAI Integration
+
+
 # -------------------------------------------------------
 def generate_ai_reply(subject, sender, snippet_or_body, email_type):
     """
@@ -338,7 +159,8 @@ def main():
     service = get_gmail_service()
 
     # Fetch all unread, then limit for "most recent" processing
-    unread_messages = fetch_all_unread_messages(service, query=args.gmail_query)
+    unread_messages = fetch_all_unread_messages(
+        service, query=args.gmail_query)
     if not unread_messages:
         print("No unread messages found.")
         return
@@ -347,7 +169,8 @@ def main():
     # If you want the strictly newest ``MAX_DRAFTS``, you may want to reverse
     # or sort by ``internalDate``.
     unread_messages = unread_messages[:MAX_DRAFTS]
-    print(f"Fetched {len(unread_messages)} unread messages (limited to {MAX_DRAFTS}).")
+    print(
+        f"Fetched {len(unread_messages)} unread messages (limited to {MAX_DRAFTS}).")
 
     # Process each unread message
     for msg_ref in unread_messages:
@@ -377,12 +200,14 @@ def main():
                 if part.get("mimeType") == "text/plain":
                     data = part.get("body", {}).get("data", "")
                     if data:
-                        body_txt = base64.urlsafe_b64decode(data.encode("utf-8")).decode("utf-8")
+                        body_txt = base64.urlsafe_b64decode(
+                            data.encode("utf-8")).decode("utf-8")
                         break
         else:
             data = payload.get("body", {}).get("data", "")
             if data:
-                body_txt = base64.urlsafe_b64decode(data.encode("utf-8")).decode("utf-8")
+                body_txt = base64.urlsafe_b64decode(
+                    data.encode("utf-8")).decode("utf-8")
 
         # Skip newsletters or spam before using any AI models
         if is_promotional_or_spam(msg_detail, body_txt):
@@ -403,10 +228,10 @@ def main():
             )
             continue
 
-
         # 2) If not, generate a new draft
         reply_subject = f"Re: {subject}" if subject else "Re: (no subject)"
-        draft_body_text = generate_ai_reply(subject, sender, snippet, email_type)
+        draft_body_text = generate_ai_reply(
+            subject, sender, snippet, email_type)
 
         # Self-grade the AI-generated reply to ensure quality
         critique = critic_email(

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ python gmail_bot.py
 
 OAuth – the first run opens a browser window; token is cached in token.pickle.
 ```
+### Development
+
+Run `flake8` before committing:
+```bash
+flake8 Draft_Replies.py gmail_bot.py utils.py
+```
+
 
 ### Tweaking behavior
 

--- a/gmail_bot.py
+++ b/gmail_bot.py
@@ -1,198 +1,20 @@
-import os
-
-# additional imports
-import json
-import requests
+import base64
 import argparse
+from utils import (
+    get_gmail_service, fetch_all_unread_messages, create_base64_message,
+    create_draft, thread_has_draft, is_promotional_or_spam,
+    critic_email, classify_email, create_ticket,
+    GMAIL_QUERY, HTTP_TIMEOUT, MAX_DRAFTS, CRITIC_THRESHOLD, MAX_RETRIES
+)
 
-from googleapiclient.discovery import build     # already imported in Draft_Replies, keep here too
-from google.auth.transport.requests import Request
-from google_auth_oauthlib.flow import InstalledAppFlow
-import pickle, base64
-
-from openai import OpenAI
 from Draft_Replies import generate_ai_reply
-import yaml
 
-
-# Load YAML config
-with open(os.path.join(os.path.dirname(__file__), "config.yaml")) as f:
-    CFG = yaml.safe_load(f)
-
-# Gmail settings
-SCOPES               = CFG["gmail"]["scopes"]
-GMAIL_CLIENT_SECRET  = CFG["gmail"]["client_secret_file"]
-GMAIL_TOKEN_FILE     = CFG["gmail"]["token_file"]
-GMAIL_QUERY          = CFG["gmail"].get("query", "is:unread")
-
-HTTP_TIMEOUT         = CFG.get("http", {}).get("timeout", 15)
-
-# OpenAI models & API key
-OPENAI_API_KEY       = os.getenv(CFG["openai"]["api_key_env"])
-CLASSIFY_MODEL       = CFG["openai"]["classify_model"]
-CLASSIFY_MAX_TOKENS  = CFG["openai"].get("classify_max_tokens", 50)
-
-# Critic settings
-CRITIC_THRESHOLD     = CFG["thresholds"]["critic_threshold"]
-MAX_RETRIES          = CFG["thresholds"]["max_retries"]
-
-MAX_DRAFTS           = CFG.get("limits", {}).get("max_drafts", 100)
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Process Gmail messages")
     parser.add_argument("--gmail-query", default=GMAIL_QUERY, help="Gmail search query")
     parser.add_argument("--timeout", type=int, default=HTTP_TIMEOUT, help="HTTP request timeout")
     return parser.parse_args()
-
-# Gmail label IDs that indicate promotional or spammy content. Messages with
-# any of these labels will be skipped entirely.
-PROMO_LABELS = {
-    "SPAM",
-    "CATEGORY_PROMOTIONS",
-    "CATEGORY_SOCIAL",
-    "CATEGORY_UPDATES",
-    "CATEGORY_FORUMS",
-}
-
-# Ticketing
-TICKET_SYSTEM        = CFG["ticket"]["system"]
-FREESCOUT_URL        = CFG["ticket"]["freescout_url"]
-FREESCOUT_KEY        = CFG["ticket"]["freescout_key"]
-
-if not OPENAI_API_KEY:
-    raise ValueError(f"Please set your {CFG['openai']['api_key_env']} environment variable.")
-
-def get_gmail_service(creds_filename=None, token_filename=None):
-    """Authenticate with Gmail using OAuth2.
-
-    Filenames can be provided as arguments or will default to the values
-    specified in ``config.yaml``.
-    """
-    creds_filename = creds_filename or GMAIL_CLIENT_SECRET
-    token_filename = token_filename or GMAIL_TOKEN_FILE
-    creds = None
-    if os.path.exists(token_filename):
-        with open(token_filename, "rb") as t:
-            creds = pickle.load(t)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(creds_filename, SCOPES)
-            creds = flow.run_local_server(port=0)
-        with open(token_filename, "wb") as t:
-            pickle.dump(creds, t)
-    return build("gmail", "v1", credentials=creds)
-
-def fetch_all_unread_messages(service, query: str = GMAIL_QUERY):
-    unread, token = [], None
-    while True:
-        resp = (
-            service.users()
-            .messages()
-            .list(userId="me", q=query, pageToken=token)
-            .execute()
-        )
-        unread.extend(resp.get("messages", []))
-        token = resp.get("nextPageToken")
-        if not token:
-            break
-    return unread
-
-def create_base64_message(sender, to, subject, body):
-    from email.mime.text import MIMEText
-    msg = MIMEText(body)
-    msg["to"], msg["from"], msg["subject"] = to, sender, subject
-    return {"raw": base64.urlsafe_b64encode(msg.as_bytes()).decode()}
-
-def create_draft(service, user_id, msg_body, thread_id=None):
-    data = {"message": msg_body}
-    if thread_id: data["message"]["threadId"] = thread_id
-    return service.users().drafts().create(userId=user_id, body=data).execute()
-
-def thread_has_draft(service, thread_id):
-    data = service.users().threads().get(userId="me", id=thread_id).execute()
-    return any(
-        "DRAFT" in (m.get("labelIds") or []) for m in data.get("messages", [])
-    )
-
-def is_promotional_or_spam(message, body_text: str) -> bool:
-    """Return True if the message looks like a newsletter or spam."""
-    labels = set(message.get("labelIds", []))
-    if labels & PROMO_LABELS:
-        return True
-    headers = {h.get("name", "").lower(): h.get("value", "") for h in message.get("payload", {}).get("headers", [])}
-    if "list-unsubscribe" in headers or "list-id" in headers:
-        return True
-    if "unsubscribe" in body_text.lower():
-        return True
-    return False
-
-def critic_email(draft: str, original: str) -> dict:
-    """Self-grade a draft reply using GPT-4.1."""
-    client = OpenAI(api_key=OPENAI_API_KEY)
-    resp = client.chat.completions.create(
-        model=CLASSIFY_MODEL,
-        messages=[
-            {
-                "role": "system",
-                "content": (
-                    "Return ONLY JSON {\"score\":1-10,\"feedback\":\"...\"} "
-                    "rating on correctness, tone, length."
-                ),
-            },
-            {"role": "assistant", "content": draft},
-            {"role": "user", "content": f"Original email:\n\n{original}"},
-        ],
-    )
-    return json.loads(resp.choices[0].message.content)
-
-def classify_email(text: str) -> dict:
-    """Classify an email and return a dict with type and importance."""
-    client = OpenAI(api_key=OPENAI_API_KEY)
-    try:
-        response = client.chat.completions.create(
-            model=CLASSIFY_MODEL,
-            messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "Categorize the email as lead, customer, or other. Return ONLY JSON {\"type\":\"lead|customer|other\",\"importance\":1-10}. NO other text."
-                    ),
-                },
-                {"role": "user", "content": text},
-            ],
-            temperature=0,
-            max_tokens=CLASSIFY_MAX_TOKENS,
-        )
-        return json.loads(response.choices[0].message.content)
-    except Exception as e:
-        print(f"Error classifying email: {e}")
-        return {"type": "other", "importance": 0}
-
-
-
-def create_ticket(subject: str, sender: str, body: str, timeout: int = HTTP_TIMEOUT):
-    if TICKET_SYSTEM != "freescout":
-        return
-    url = f"{FREESCOUT_URL.rstrip('/')}/api/conversations"
-    payload = {
-        "type": "email",
-        "subject": subject or "(no subject)",
-        "customer": {"email": sender},
-        "threads": [{"type": "customer", "text": body}],
-    }
-    r = requests.post(
-        url,
-        headers={
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "X-FreeScout-API-Key": FREESCOUT_KEY,
-        },
-        json=payload,
-        timeout=timeout,
-    )
-    r.raise_for_status()
 
 
 def main():
@@ -260,4 +82,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,177 @@
+import os
+import json
+import base64
+import pickle
+from email.mime.text import MIMEText
+
+import requests
+import yaml
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from openai import OpenAI
+
+
+with open(os.path.join(os.path.dirname(__file__), "config.yaml")) as f:
+    CFG = yaml.safe_load(f)
+
+SCOPES = CFG["gmail"]["scopes"]
+GMAIL_CLIENT_SECRET = CFG["gmail"]["client_secret_file"]
+GMAIL_QUERY = CFG["gmail"].get("query", "is:unread")
+MAX_DRAFTS = CFG.get("limits", {}).get("max_drafts", 100)
+CRITIC_THRESHOLD = CFG["thresholds"]["critic_threshold"]
+MAX_RETRIES = CFG["thresholds"]["max_retries"]
+GMAIL_TOKEN_FILE = CFG["gmail"]["token_file"]
+HTTP_TIMEOUT = CFG.get("http", {}).get("timeout", 15)
+
+OPENAI_API_KEY = os.getenv(CFG["openai"]["api_key_env"])
+CLASSIFY_MODEL = CFG["openai"]["classify_model"]
+CLASSIFY_MAX_TOKENS = CFG["openai"].get("classify_max_tokens", 50)
+
+PROMO_LABELS = {
+    "SPAM",
+    "CATEGORY_PROMOTIONS",
+    "CATEGORY_SOCIAL",
+    "CATEGORY_UPDATES",
+    "CATEGORY_FORUMS",
+}
+
+TICKET_SYSTEM = CFG["ticket"]["system"]
+FREESCOUT_URL = CFG["ticket"]["freescout_url"]
+FREESCOUT_KEY = CFG["ticket"]["freescout_key"]
+
+
+# ----- Gmail helpers -----
+
+def get_gmail_service(creds_filename=None, token_filename=None):
+    """Return an authenticated Gmail service instance."""
+    creds_filename = creds_filename or GMAIL_CLIENT_SECRET
+    token_filename = token_filename or GMAIL_TOKEN_FILE
+    creds = None
+    if os.path.exists(token_filename):
+        with open(token_filename, "rb") as t:
+            creds = pickle.load(t)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(creds_filename, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(token_filename, "wb") as t:
+            pickle.dump(creds, t)
+    return build("gmail", "v1", credentials=creds)
+
+
+def fetch_all_unread_messages(service, query):
+    unread, token = [], None
+    while True:
+        resp = (
+            service.users()
+            .messages()
+            .list(userId="me", q=query, pageToken=token)
+            .execute()
+        )
+        unread.extend(resp.get("messages", []))
+        token = resp.get("nextPageToken")
+        if not token:
+            break
+    return unread
+
+
+def create_base64_message(sender, to, subject, body):
+    msg = MIMEText(body)
+    msg["to"], msg["from"], msg["subject"] = to, sender, subject
+    return {"raw": base64.urlsafe_b64encode(msg.as_bytes()).decode()}
+
+
+def create_draft(service, user_id, msg_body, thread_id=None):
+    data = {"message": msg_body}
+    if thread_id:
+        data["message"]["threadId"] = thread_id
+    return service.users().drafts().create(userId=user_id, body=data).execute()
+
+
+def thread_has_draft(service, thread_id):
+    data = service.users().threads().get(userId="me", id=thread_id).execute()
+    return any("DRAFT" in (m.get("labelIds") or []) for m in data.get("messages", []))
+
+
+def is_promotional_or_spam(message, body_text):
+    labels = set(message.get("labelIds", []))
+    if labels & PROMO_LABELS:
+        return True
+    headers = {
+        h.get("name", "").lower(): h.get("value", "")
+        for h in message.get("payload", {}).get("headers", [])
+    }
+    if "list-unsubscribe" in headers or "list-id" in headers:
+        return True
+    if "unsubscribe" in body_text.lower():
+        return True
+    return False
+
+
+def critic_email(draft, original):
+    """Self-grade a draft reply using GPT-4.1."""
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    resp = client.chat.completions.create(
+        model=CLASSIFY_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Return ONLY JSON {\"score\":1-10,\"feedback\":\"...\"} rating on correctness, tone, length."
+                ),
+            },
+            {"role": "assistant", "content": draft},
+            {"role": "user", "content": f"Original email:\n\n{original}"},
+        ],
+    )
+    return json.loads(resp.choices[0].message.content)
+
+
+def classify_email(text):
+    """Classify an email and return a dict with type and importance."""
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    try:
+        resp = client.chat.completions.create(
+            model=CLASSIFY_MODEL,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Categorize the email as lead, customer, or other. Return ONLY JSON {\"type\":\"lead|customer|other\",\"importance\":1-10}. NO other text."
+                    ),
+                },
+                {"role": "user", "content": text},
+            ],
+            temperature=0,
+            max_tokens=CLASSIFY_MAX_TOKENS,
+        )
+        return json.loads(resp.choices[0].message.content)
+    except Exception as e:
+        print(f"Error classifying email: {e}")
+        return {"type": "other", "importance": 0}
+
+
+def create_ticket(subject, sender, body, timeout=HTTP_TIMEOUT):
+    if TICKET_SYSTEM != "freescout":
+        return
+    url = f"{FREESCOUT_URL.rstrip('/')}/api/conversations"
+    payload = {
+        "type": "email",
+        "subject": subject or "(no subject)",
+        "customer": {"email": sender},
+        "threads": [{"type": "customer", "text": body}],
+    }
+    r = requests.post(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-FreeScout-API-Key": FREESCOUT_KEY,
+        },
+        json=payload,
+        timeout=timeout,
+    )
+    r.raise_for_status()


### PR DESCRIPTION
## Summary
- extract shared Gmail/OpenAI helpers into `utils.py`
- update scripts to import from the shared module
- add a `.flake8` config and linter instructions

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_686aa2c1a2e8832b81320eea507803ef