### PR TITLE
Enforce webhook authentication by default when secret is unset

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -226,3 +226,6 @@ webhook:
     nonce_cache_size: 10000
     # Time-to-live for nonce cache entries (seconds)
     nonce_cache_ttl_seconds: 600  # 10 minutes
+    # Development-only escape hatch: allow unsigned webhooks when no secret is set
+    # Keep false in production.
+    allow_unauthenticated: false


### PR DESCRIPTION
### Motivation

- Prevent unsigned webhook requests from being accepted silently when a webhook secret is not configured by making the secure behavior the default.
- Provide an explicit, documented development escape hatch for dev/test environments that need unsigned webhooks.

### Description

- Fail-closed at the `/freescout` webhook endpoint: if `FREESCOUT_WEBHOOK_SECRET` is missing and `webhook.security.allow_unauthenticated` is not enabled, the endpoint now returns `503` and logs a failure reason.
- Added a boolean coercion helper `_coerce_bool` to safely interpret common string/boolean representations for webhook config parsing.
- Added `webhook.security.allow_unauthenticated` (default `false`) to `config.yaml` and surfaced it via settings in `utils.py` as `WEBHOOK_ALLOW_UNAUTHENTICATED`.
- Updated settings validation in `utils.py` to require either a webhook secret or an explicit unauthenticated opt-in when webhooks are enabled, and adjusted the webhook handler logging behavior accordingly.
- Added API-level unit tests in `tests/test_webhook_validation.py` to verify rejection when secret is missing and acceptance when the insecure override is explicitly enabled.

### Testing

- Ran `pytest -q tests/test_webhook_validation.py` and the webhook validation tests passed (27 passed).
- Ran the full test suite `pytest -q` and all tests passed (75 passed).
- Ran `ruff check .` which reported pre-existing lint issues in `tests/test_utils.py` (5 fixable unused-import errors) that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699baa1a4a98832bbac40b23cb21c7fb)